### PR TITLE
Add basic CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+
+- package-ecosystem: pip
+  directory: /
+  schedule:
+    interval: monthly
+  groups:
+    all:
+      patterns:
+      - '*'
+
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly
+  groups:
+    all:
+      patterns:
+      - '*'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: python
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+jobs:
+
+  python:
+    strategy:
+      matrix:
+        os:
+        - macos-latest
+        - macos-latest-large # Apple silicon macOS
+        - ubuntu-latest
+        - windows-latest
+        python-version:
+        - 3.9
+        - 3.12
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - run: pip install .[dev]
+
+    - run: ruff check .
+
+    - run: ruff format --check .
+
+    - run: python -m build --wheel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         os:
         - macos-latest
-        - macos-latest-large # Apple silicon macOS
         - ubuntu-latest
         - windows-latest
         python-version:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.egg-info/
+build/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Ptah
 
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Documentation Status](https://readthedocs.org/projects/ptah/badge/?version=latest)](https://ptah.readthedocs.io/en/latest/?badge=latest)
 
 Kubernetes development toolkit, with a focus on rapid iteration and local

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Ptah
 
+[![Documentation Status](https://readthedocs.org/projects/ptah/badge/?version=latest)](https://ptah.readthedocs.io/en/latest/?badge=latest)
+
 Kubernetes development toolkit, with a focus on rapid iteration and local
 hosting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,6 @@ doc = [
     "mkdocs==1.6.0",
     "mkdocs-material==9.5.25",
 ]
+
+[tool.setuptools.package-data]
+ptah = ["**/*.py"]


### PR DESCRIPTION
Broadly imitates https://github.com/dkmiller/modern-python-package/tree/main/.github/workflows.

~~From https://github.com/actions/runner-images/issues/8439, this should support the new M1 chips.~~

Sadly, you need to pay for those runners

>  The job was not started because recent account payments have failed or your spending limit needs to be increased. Please check the 'Billing & plans' section in your settings.Show less
