### PR TITLE
Minor tweaks to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,16 +52,28 @@ jobs:
       if: ${{ steps.singleton.outputs.value }}
 
   pypi-publish:
-    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
+    needs: python
+    if: ${{ github.ref == 'refs/heads/main' }}
     environment:
       name: pypi
       url: https://pypi.org/p/ptah-cli
     permissions:
+      attestations: write
+      contents: read
       id-token: write
+
     steps:
+
     - uses: actions/download-artifact@v4
       with:
         name: release-dists
         path: dist/
+
+    -  uses: actions/attest-build-provenance@v1
+       with:
+         subject-path: dist/*.whl
+
     - uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        print-hash: true

--- a/.github/workflows/readthedocs.yml
+++ b/.github/workflows/readthedocs.yml
@@ -1,0 +1,17 @@
+name: readthedocs/actions
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  documentation-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: ptah

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ptah-cli"
 readme = "README.md"
-version = "0.0.0"
+version = "0.0.1"
 authors = [
     { name = "Dan Miller", email = "daniel.keegan.miller@gmail.com" }
 ]


### PR DESCRIPTION
Reference:

- https://github.blog/changelog/2024-05-02-artifact-attestations-public-beta/
- https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds