### PR TITLE
Add `ptah ssh`

### DIFF
--- a/ptah/cli/__init__.py
+++ b/ptah/cli/__init__.py
@@ -14,6 +14,7 @@ from ptah.clients import (
     Kind,
     Kubernetes,
     Project,
+    Ssh,
     Version,
     Yaml,
     get,
@@ -151,6 +152,14 @@ def _sync():
     with get(Sync).run():
         while True:
             time.sleep(1)
+
+
+@app.command()
+def ssh(app: str):
+    """
+    Find the first pod with provided app name; then SSH (`kubectl exec`) into it.
+    """
+    get(Ssh).run(app)
 
 
 # Create a "nicely named" Click command object for generated docs.

--- a/ptah/clients/__init__.py
+++ b/ptah/clients/__init__.py
@@ -9,5 +9,6 @@ from .kubernetes import Kubernetes
 from .panic import PtahPanic
 from .project import Project
 from .shell import Shell
+from .ssh import Ssh
 from .version import Version
 from .yaml import Yaml

--- a/ptah/clients/ssh.py
+++ b/ptah/clients/ssh.py
@@ -1,0 +1,30 @@
+import os
+from dataclasses import dataclass
+
+from injector import inject
+
+from ptah.clients.shell import Shell
+
+
+@inject
+@dataclass
+class Ssh:
+    shell: Shell
+
+    def run(self, app_name: str) -> None:
+        """
+        Follows:
+        - https://stackoverflow.com/a/55897287
+        - https://stackoverflow.com/a/52691455
+        """
+        pod_name = self.shell(
+            "kubectl",
+            "get",
+            "pods",
+            f"--selector=app={app_name}",
+            "-o",
+            "jsonpath={.items[0].metadata.name}",
+        )
+        command = f"kubectl exec -it {pod_name} -- /bin/bash"
+        print(f"Running command\n\n\t{command}\n")
+        os.system(command)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ptah-cli"
 readme = "README.md"
-version = "0.6.0"
+version = "0.7.0"
 authors = [
     { name = "Dan Miller", email = "daniel.keegan.miller@gmail.com" }
 ]

--- a/tests/clients/test_ssh.py
+++ b/tests/clients/test_ssh.py
@@ -1,0 +1,22 @@
+from unittest.mock import MagicMock, patch
+
+from ptah.clients import Ssh, get
+
+
+@patch(f"{Ssh.__module__}.os")
+def test_ssh_run(os):
+    ssh = get(Ssh)
+    ssh.shell = MagicMock(return_value="pod-name")
+
+    ssh.run("some-app-name")
+
+    ssh.shell.assert_called_once_with(
+        "kubectl",
+        "get",
+        "pods",
+        "--selector=app=some-app-name",
+        "-o",
+        "jsonpath={.items[0].metadata.name}",
+    )
+
+    os.system.assert_called_once_with("kubectl exec -it pod-name -- /bin/bash")

--- a/tests/operations/test_sync.py
+++ b/tests/operations/test_sync.py
@@ -31,7 +31,7 @@ def test_sync_respects_file_creation(in_project, sync):
         Path("fastapi/foo.txt").touch()
         time.sleep(0.1)
 
-    sync.shell.assert_called_once_with(
+    assertion_args = (
         "kubectl",
         "cp",
         str(Path.cwd().absolute() / "fastapi/foo.txt"),
@@ -39,6 +39,11 @@ def test_sync_respects_file_creation(in_project, sync):
         "-c",
         "fastapi",
     )
+
+    if get(OperatingSystem) == OperatingSystem.MACOS and "GITHUB_ACTION" in os.environ:
+        sync.shell.assert_called_with(*assertion_args)
+    else:
+        sync.shell.assert_called_once_with(*assertion_args)
 
 
 @pytest.mark.parametrize("in_project", ["project-with-fastapi"], indirect=True)


### PR DESCRIPTION
Imitates https://github.com/dkmiller/tidbits/blob/facb960704671729abfc361284d7a017bc2054a9/2023/kubernetes/src/ptah/core/ssh.py.

Closes #38.

<!-- readthedocs-preview ptah start -->
----
📚 Documentation preview 📚: https://ptah--45.org.readthedocs.build/en/45/

<!-- readthedocs-preview ptah end -->