### PR TITLE
Fix deprecation error against latest click

### DIFF
--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,6 +1,6 @@
 import re
 
-from click import BaseCommand
+from click import Command
 from typer.testing import CliRunner
 
 from ptah.cli import app
@@ -9,7 +9,7 @@ from ptah.cli import app
 def test_cli_click_object():
     from ptah.cli import ptah
 
-    assert isinstance(ptah, BaseCommand)
+    assert isinstance(ptah, Command)
 
 
 def test_cli_version():


### PR DESCRIPTION
BaseCommand is deprecated in Click 8.2: https://click.palletsprojects.com/en/stable/changes/#version-8-2-0

<!-- readthedocs-preview ptah start -->
----
📚 Documentation preview 📚: https://ptah--54.org.readthedocs.build/en/54/

<!-- readthedocs-preview ptah end -->